### PR TITLE
faker 15.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.8.1" %}
+{% set version = "15.3.1" %}
 
 package:
   name: faker
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/F/Faker/Faker-{{ version }}.tar.gz
-  sha256: ccd76cd86a49f1042811faaa3a7d1b094fcf8e60a1ec286190417bbb5a3f2f76
+  sha256: b9dd2fd9a9ac68a4e0c5040cd9e9bfaa099fa8dd15bae5f01f224a45431818d5
 
 build:
   number: 1


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 29fe4e4..dc6852a 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.8.1" %}
+{% set version = "15.3.1" %}
 
 package:
   name: faker
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/F/Faker/Faker-{{ version }}.tar.gz
-  sha256: ccd76cd86a49f1042811faaa3a7d1b094fcf8e60a1ec286190417bbb5a3f2f76
+  sha256: b9dd2fd9a9ac68a4e0c5040cd9e9bfaa099fa8dd15bae5f01f224a45431818d5
 
 build:
   number: 1

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/joke2k/faker/releases
[Diff between the latest and previous upstream releases](https://github.com/joke2k/faker/compare/15.2.0...15.3.1)
Changelog: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
Requirements:
 * setup.cfg:  https://github.com/joke2k/faker/blob/v15.3.1/setup.cfg
 * setup.py:  https://github.com/joke2k/faker/blob/v15.3.1/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Package's statistics**
<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 15.3.1
 * Release on PyPi:
    * version: 15.3.2
    * date: 2022-11-14T16:15:01
* [PyPi history](https://pypi.org/project/faker/#history)
 * Popularity: 
    * 3 months downloads: 52415.0
    * All time:  678306 downloads -  faker  15.3.2  Faker is a Python package that generates fake data for you  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/joke2k/faker/tree/v15.3.1 exists
2. - [ ] The upstream url error:
    https://faker.readthedocs.io
    302
3. - [ ] Check the pinnings
4. - [x] https://github.com/joke2k/faker/blob/master/CHANGELOG.md exists
5. - [ ] Additional research
    https://github.com/joke2k/faker/issues
    200
6. - [x] `dev_url` is present
    https://github.com/joke2k/faker
7. - [ ] `doc_url` error:
    https://faker.readthedocs.io
    302
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE.txt is present
16. - [x] License: MIT
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |

17. - [x] license_family MIT is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/faker-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/faker-feedstock/tree/15.3.1)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/faker)
* [Diff between upstream and feature branch](https://github.com/conda-forge/faker-feedstock/compare/main...AnacondaRecipes:15.3.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/faker-feedstock/compare/master...AnacondaRecipes:15.3.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/faker-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 15.3.1 git@github.com:AnacondaRecipes/faker-feedstock.git
```
