### PR TITLE
faker 16.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.8.1" %}
+{% set version = "16.6.1" %}
 
 package:
   name: faker
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/F/Faker/Faker-{{ version }}.tar.gz
-  sha256: ccd76cd86a49f1042811faaa3a7d1b094fcf8e60a1ec286190417bbb5a3f2f76
+  sha256: b76e5d2405470e3d38d37d1bfaa9d9bbf171bdf41c814f5bbd8117b121f6bccb
 
 build:
   number: 1


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 29fe4e4..8ac845a 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.8.1" %}
+{% set version = "16.6.1" %}
 
 package:
   name: faker
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/F/Faker/Faker-{{ version }}.tar.gz
-  sha256: ccd76cd86a49f1042811faaa3a7d1b094fcf8e60a1ec286190417bbb5a3f2f76
+  sha256: b76e5d2405470e3d38d37d1bfaa9d9bbf171bdf41c814f5bbd8117b121f6bccb
 
 build:
   number: 1

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 16.6.1

* [PyPi history](https://pypi.org/project/faker/#history)
 * Popularity: 
    * 3 months downloads: 50185.0


</details>

**Other checks:**

<details>

1. - [x] https://github.com/joke2k/faker/tree/v16.6.1 exists
2. - [ ] The upstream url error:
    https://faker.readthedocs.io
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/joke2k/faker/tree/v16.6.1
    200
5. - [ ] Additional research
    https://github.com/joke2k/faker/issues
    
6. - [ ] `dev_url` error:
    https://github.com/joke2k/faker
    
7. - [ ] `doc_url` error:
    https://faker.readthedocs.io
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE.txt is present

16. - [x] license_family MIT is present
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List


</details>


</details>

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 16.6.1

* [PyPi history](https://pypi.org/project/faker/#history)
 * Popularity: 
    * 3 months downloads: 50185.0


</details>

**Other checks:**

<details>

1. - [x] https://github.com/joke2k/faker/tree/v16.6.1 exists
2. - [ ] The upstream url error:
    https://faker.readthedocs.io
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/joke2k/faker/tree/v16.6.1
    200
5. - [ ] Additional research
    https://github.com/joke2k/faker/issues
    
6. - [ ] `dev_url` error:
    https://github.com/joke2k/faker
    
7. - [ ] `doc_url` error:
    https://faker.readthedocs.io
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE.txt is present

16. - [x] license_family MIT is present
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List


</details>


</details>

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/joke2k/faker/releases
[Diff between the latest and previous upstream releases](https://github.com/joke2k/faker/compare/8.8.1...16.6.1)
License: https://github.com/joke2k/faker/blob/master/LICENSE.txt
Changelog: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
Requirements:
 * setup.cfg:  https://github.com/joke2k/faker/blob/v16.6.1/setup.cfg
 * setup.py:  https://github.com/joke2k/faker/blob/v16.6.1/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 16.6.1
 * Release on PyPi:
    * version: 17.0.0
    * date: 2023-02-13T17:20:08
* [PyPi history](https://pypi.org/project/faker/#history)
 * Popularity: 
    * 3 months downloads: 50185.0
    * All time:  715849 downloads -  faker  16.8.1  Faker is a Python package that generates fake data for you  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/joke2k/faker/tree/v16.6.1 exists
2. - [ ] The upstream url error:
    https://faker.readthedocs.io
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/joke2k/faker/tree/v16.6.1
    200
5. - [ ] Additional research
    https://github.com/joke2k/faker/issues
    
6. - [ ] `dev_url` error:
    https://github.com/joke2k/faker
    
7. - [ ] `doc_url` error:
    https://faker.readthedocs.io
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE.txt is present

16. - [x] license_family MIT is present
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/faker-feedstock/recipe/meta.yaml
Dependencies: ['text-unidecode ==1.3', 'setuptools', 'wheel', 'python >=3.6', 'pip', 'python-dateutil >=2.4']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 16**


</details>

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/joke2k/faker/releases
[Diff between the latest and previous upstream releases](https://github.com/joke2k/faker/compare/8.8.1...16.6.1)
License: https://github.com/joke2k/faker/blob/master/LICENSE.txt
Changelog: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
Requirements:
 * setup.cfg:  https://github.com/joke2k/faker/blob/v16.6.1/setup.cfg
 * setup.py:  https://github.com/joke2k/faker/blob/v16.6.1/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 16.6.1
 * Release on PyPi:
    * version: 17.0.0
    * date: 2023-02-13T17:20:08
* [PyPi history](https://pypi.org/project/faker/#history)
 * Popularity: 
    * 3 months downloads: 50185.0
    * All time:  715849 downloads -  faker  16.8.1  Faker is a Python package that generates fake data for you  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/joke2k/faker/tree/v16.6.1 exists
2. - [ ] The upstream url error:
    https://faker.readthedocs.io
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/joke2k/faker/tree/v16.6.1
    200
5. - [ ] Additional research
    https://github.com/joke2k/faker/issues
    
6. - [ ] `dev_url` error:
    https://github.com/joke2k/faker
    
7. - [ ] `doc_url` error:
    https://faker.readthedocs.io
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE.txt is present

16. - [x] license_family MIT is present
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/faker-feedstock/recipe/meta.yaml
Dependencies: ['wheel', 'python-dateutil >=2.4', 'text-unidecode ==1.3', 'setuptools', 'pip', 'python >=3.6']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 16**


</details>

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/joke2k/faker/releases
[Diff between the latest and previous upstream releases](https://github.com/joke2k/faker/compare/8.8.1...16.6.1)
License: https://github.com/joke2k/faker/blob/master/LICENSE.txt
Changelog: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
Requirements:
 * setup.cfg:  https://github.com/joke2k/faker/blob/v16.6.1/setup.cfg
 * setup.py:  https://github.com/joke2k/faker/blob/v16.6.1/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 16.6.1
 * Release on PyPi:
    * version: 17.0.0
    * date: 2023-02-13T17:20:08
* [PyPi history](https://pypi.org/project/faker/#history)
 * Popularity: 
    * 3 months downloads: 50185.0
    * All time:  715851 downloads -  faker  16.8.1  Faker is a Python package that generates fake data for you  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/joke2k/faker/tree/v16.6.1 exists
2. - [ ] The upstream url error:
    https://faker.readthedocs.io
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/joke2k/faker/tree/v16.6.1
    200
5. - [ ] Additional research
    https://github.com/joke2k/faker/issues
    
6. - [ ] `dev_url` error:
    https://github.com/joke2k/faker
    
7. - [ ] `doc_url` error:
    https://faker.readthedocs.io
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE.txt is present

16. - [x] license_family MIT is present
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/faker-feedstock/recipe/meta.yaml
Dependencies: ['text-unidecode ==1.3', 'setuptools', 'wheel', 'python >=3.6', 'pip', 'python-dateutil >=2.4']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 16**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/faker-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/faker-feedstock/tree/16.6.1)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/faker)
* [Diff between upstream and feature branch](https://github.com/conda-forge/faker-feedstock/compare/main...AnacondaRecipes:16.6.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/faker-feedstock/compare/master...AnacondaRecipes:16.6.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/faker-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 16.6.1 git@github.com:AnacondaRecipes/faker-feedstock.git
```
