### PR TITLE
faker 17.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.8.1" %}
+{% set version = "17.6.0" %}
 
 package:
   name: faker
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/F/Faker/Faker-{{ version }}.tar.gz
-  sha256: ccd76cd86a49f1042811faaa3a7d1b094fcf8e60a1ec286190417bbb5a3f2f76
+  sha256: 51f37ff9df710159d6d736d0ba1c75e063430a8c806b91334d7794305b5a6114
 
 build:
   number: 1


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 29fe4e4..03d0f9c 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.8.1" %}
+{% set version = "17.6.0" %}
 
 package:
   name: faker
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/F/Faker/Faker-{{ version }}.tar.gz
-  sha256: ccd76cd86a49f1042811faaa3a7d1b094fcf8e60a1ec286190417bbb5a3f2f76
+  sha256: 51f37ff9df710159d6d736d0ba1c75e063430a8c806b91334d7794305b5a6114
 
 build:
   number: 1

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/joke2k/faker/releases
[Diff between the latest and previous upstream releases](https://github.com/joke2k/faker/compare/8.8.1...17.6.0)
License: https://github.com/joke2k/faker/blob/master/LICENSE.txt
Changelog: https://github.com/joke2k/faker/blob/master/CHANGELOG.md
Requirements:
 * setup.cfg:  https://github.com/joke2k/faker/blob/v17.6.0/setup.cfg
 * setup.py:  https://github.com/joke2k/faker/blob/v17.6.0/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platforms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 17.6.0
 * Release on PyPi:
    * version: 17.6.0
    * date: 2023-03-03T16:59:17
* [PyPi history](https://pypi.org/project/faker/#history)
 * Popularity: 
    * 3 months downloads: 37459.0
    * All time:  726076 downloads -  faker  17.6.0  Faker is a Python package that generates fake data for you  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the 'build_number' is correct
3. - [x] has 'setuptools'
5. - [x] has 'wheel'
7. - [x] 'pip' in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is 'architecture specific'
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE.txt is present

14. - [x] license_family MIT is present
16. - [x] License: MIT
    - [x] License is 'spdx' compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                       |
|:---------------------------------|
| HPND-sell-variant-MIT-disclaimer |
| MIT                              |
| MIT-0                            |
| MIT-advertising                  |
| MIT-CMU                          |
| MIT-enna                         |
| MIT-feh                          |
| MIT-Modern-Variant               |
| MIT-open-group                   |
| MIT-Wu                           |
| MITNFA                           |
</details>

**Check dependency issues:**

<details>
../aggregate/faker-feedstock/recipe/meta.yaml
Dependencies: ['python >=3.6', 'setuptools', 'pip', 'wheel', 'python-dateutil >=2.4', 'text-unidecode ==1.3']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>
**Other:**

<details>
Checking 'faker' recipe...
~/OneDrive - SoftServe, Inc/src/aggregate/faker-feedstock/recipe ~/OneDrive - SoftServe, Inc/src/finder
[32m>>> Easy: noarch python recipe <<<[0m
--- Build Requirements ---
>> Empty Host Section <<
--- Host Requirements ---
pip: main
setuptools: main
wheel: main
--- Run Requirements ---
python-dateutil >=2.4: main
text-unidecode ==1.3: main
~/OneDrive - SoftServe, Inc/src/finder

</details>

<details>

https://repo.anaconda.com/pkgs/main/noarch
faker-8.8.1-pyhd3eb1b0_1.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-64
https://repo.anaconda.com/pkgs/main/linux-ppc64le
https://repo.anaconda.com/pkgs/main/linux-aarch64/
https://repo.anaconda.com/pkgs/main/linux-s390x/
https://repo.anaconda.com/pkgs/main/osx-64
https://repo.anaconda.com/pkgs/main/osx-arm64/
https://repo.anaconda.com/pkgs/main/win-64

</details>

<details>

          name version           spec
0  factory_boy   3.2.0  faker >=0.7.0
1  factory_boy   3.1.0  faker >=0.7.0
2  factory_boy   3.0.1  faker >=0.7.0
3  factory_boy  2.12.0  faker >=0.7.0
4  factory_boy  2.11.1  faker >=0.7.0
5  factory_boy  2.10.0  faker >=0.7.0
6  factory_boy   2.9.2  faker >=0.7.0

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/faker-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/faker-feedstock/tree/17.6.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/faker)
* [Diff between upstream and feature branch](https://github.com/conda-forge/faker-feedstock/compare/main...AnacondaRecipes:17.6.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/faker-feedstock/compare/master...AnacondaRecipes:17.6.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/faker-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 17.6.0 git@github.com:AnacondaRecipes/faker-feedstock.git
```
