### PR TITLE
faker 30.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
   run:
     - python
     - python-dateutil >=2.4
+    - typing_extensions
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "25.8.0" %}
+{% set name = "faker" %}
+{% set version = "30.8.1" %}
 
 package:
-  name: faker
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/F/Faker/Faker-{{ version }}.tar.gz
-  sha256: bdec5f2fb057d244ebef6e0ed318fea4dcbdf32c3a1a010766fc45f5d68fc68d
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 93e8b70813f76d05d98951154681180cb795cfbcff3eced7680d963bcc0da2a9
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5691](https://anaconda.atlassian.net/browse/PKG-5691)
- [Upstream repository](https://github.com/joke2k/faker/tree/v30.8.1)
- [Upstream changelog/diff](https://github.com/joke2k/faker/blob/v30.8.1/CHANGELOG.md)

### Explanation of changes:

- Update version and sha256
- Update dependencies


[PKG-5691]: https://anaconda.atlassian.net/browse/PKG-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ